### PR TITLE
Changed activate on-screen keyboard mapping to R2 to fix USB keyboard spacebar problem

### DIFF
--- a/keyboard.c
+++ b/keyboard.c
@@ -15,7 +15,7 @@
 #define KEY_BACKSPACE SDLK_BACKSPACE // R
 #define KEY_SHIFT SDLK_TAB // L
 #define KEY_LOCATION SDLK_LSHIFT // Y
-#define KEY_ACTIVATE SDLK_SPACE // X
+#define KEY_ACTIVATE SDLK_PAGEDOWN // X  // (was spacebar and so made using an external keyboard impossible as all spaces were activating onscreen keyboard)
 #define KEY_QUIT SDLK_HOME // SELECT
 #define KEY_HELP SDLK_RETURN // START
 #define KEY_TAB SDLK_ESCAPE // START


### PR DESCRIPTION
Now the spacebar on an external keyboard can be used, previously it was activating the on-screen keyboard every time and therefore making external keyboards impossible to use.

Now external USB keyboards can be used, vastly speeding up text entry, tested on my RG350 with an external USB keyboard.